### PR TITLE
Random seed as an option

### DIFF
--- a/bin/rtanque
+++ b/bin/rtanque
@@ -26,7 +26,9 @@ LONGDESC
   method_option :gui, :default => true, :type => :boolean, :banner => 'false to run headless'
   method_option :gc, :default => true, :type => :boolean, :banner => 'disable GC (EXPERIMENTAL)'
   method_option :quiet, :aliases => '-q', :default => false, :type => :boolean, :banner => 'disable chatter'
+  method_option :seed, :default => Kernel.srand, :type => :numeric, :banner => 'random number seed value'
   def start(*brain_paths)
+    Kernel.srand(options[:seed])
     runner = RTanque::Runner.new(options[:width], options[:height], options[:max_ticks])
     brain_paths.each { |brain_path|
       begin

--- a/lib/rtanque/heading.rb
+++ b/lib/rtanque/heading.rb
@@ -59,7 +59,7 @@ module RTanque
     end
 
     def self.rand
-      self.new(Float.send(:rand) * FULL_ANGLE)
+      self.new(Kernel.rand * FULL_ANGLE)
     end
 
     attr_reader :radians


### PR DESCRIPTION
This allows the same battle to be run repeatedly with the same outcome by passing the random number seed as an option:

```
rtanque start bots/my_bot bots/camper --seed 123456789
```

If the option is not passed, it's random like always, and prints out the seed used so that you can replay a battle as you please.
