### PR TITLE
Fixed collision detection when a bullet passes through a bot.

### DIFF
--- a/lib/rtanque/point.rb
+++ b/lib/rtanque/point.rb
@@ -136,5 +136,21 @@ module RTanque
     def distance(other_point)
       self.class.distance(self, other_point)
     end
+    
+    def +(other_point)
+      self.class.new self.x + other_point.x, self.y + other_point.y
+    end
+
+    def -(other_point)
+      self.class.new self.x - other_point.x, self.y - other_point.y
+    end
+
+    def /(denominator)
+      self.class.new self.x / denominator, self.y / denominator
+    end
+
+    def *(v)
+      self.class.new self.x * v, self.y * v
+    end
   end
 end

--- a/lib/rtanque/shell.rb
+++ b/lib/rtanque/shell.rb
@@ -4,6 +4,7 @@ module RTanque
     RATIO = Configuration.shell.ratio
     SHELL_SPEED_FACTOR = Configuration.shell.speed_factor
     attr_reader :bot, :arena, :fire_power
+    attr_accessor :start_position
 
     def self.speed fire_power
       fire_power * SHELL_SPEED_FACTOR
@@ -13,6 +14,7 @@ module RTanque
       @bot = bot
       @arena = bot.arena
       @fire_power = fire_power
+      self.start_position = position
       self.position = position
       self.heading = heading
       self.speed = self.class.speed(fire_power) # TODO: add bot's relative speed in this heading
@@ -30,10 +32,50 @@ module RTanque
     def dead!
       @dead = true
     end
+    
+    def last_position
+      if self.start_position == self.position
+        self.start_position
+      else
+        self.position.move self.heading + Math::PI, self.speed, false
+      end
+    end
+
+    def hit_test hit_bot
+      if self.start_position == self.position
+        return hit_bot.position.within_radius?(self.position, Bot::RADIUS)
+      end
+
+      #where was the shell last tick
+      origin = last_position
+
+      #line between shells
+      v = self.position - origin
+
+      #line to center of bot
+      u = hit_bot.position - origin
+
+      #project bot vector onto destination vector
+      #see http://stackoverflow.com/a/1079478
+      udotv = u.x * v.x + u.y * v.y
+      
+      vmag = Math::sqrt(v.x ** 2 + v.y ** 2)
+      vnorm = v / vmag
+
+      proj = (vnorm * udotv) / vmag
+      projmag = Math::sqrt(proj.x ** 2 + proj.y ** 2)
+      
+      if (projmag > vmag)
+        return false
+      end
+
+      dist = proj.distance u
+      dist <= Bot::RADIUS
+    end
 
     def hits(bots, &on_hit)
       bots.each do |hit_bot|
-        if hit_bot.position.within_radius?(self.position, Bot::RADIUS)
+        if hit_test hit_bot
           self.dead!
           on_hit.call(self.bot, hit_bot) if on_hit
           break

--- a/spec/rtanque/shell_spec.rb
+++ b/spec/rtanque/shell_spec.rb
@@ -27,8 +27,50 @@ describe RTanque::Shell do
       expect { |p| shell.hits(bots, &p) }.to yield_with_args(bot, bots[0])
     end
 
+    it 'should hit bot when next location is through bot' do
+      bots = [mockbot(10 + RTanque::Bot::RADIUS - 0.01, 10 + RTanque::Bot::RADIUS, 'deadbot')]
+      shell.speed = RTanque::Bot::RADIUS * 5
+      shell.position = shell.position.move(shell.heading, shell.speed)
+      expect { |p| shell.hits(bots, &p) }.to yield_with_args(bot, bots[0])
+    end 
+    
+    it 'should be able to detect the last position based on the heading and speed' do 
+      shell.speed = 1
+      start_position = shell.position
+      shell.position = shell.position.move shell.heading, shell.speed
+      expect(start_position).to eq shell.last_position
+    end
+
+    it 'should hit bot when next location through middle of bot' do
+      bots = [mockbot(10, 10 + RTanque::Bot::RADIUS, 'deadbot')]
+      shell.speed = RTanque::Bot::RADIUS * 5
+      shell.position = shell.position.move(shell.heading, shell.speed)
+    end 
+
+    it 'should hit bot when next location through right of bot' do
+      bots = [mockbot(10 - RTanque::Bot::RADIUS, 10 + RTanque::Bot::RADIUS, 'deadbot')]
+      shell.speed = RTanque::Bot::RADIUS * 5
+      shell.position = shell.position.move(shell.heading, shell.speed)
+      expect { |p| shell.hits(bots, &p) }.to yield_with_args(bot, bots[0])
+    end 
+
+    it 'should not hit bot when next location whiffs right of bot' do
+      bots = [mockbot(10 - RTanque::Bot::RADIUS - 0.001, 10 + RTanque::Bot::RADIUS, 'not so deadbot')]
+      shell.speed = RTanque::Bot::RADIUS * 5
+      shell.position = shell.position.move(shell.heading, shell.speed)
+      expect { |p| shell.hits(bots, &p) }.not_to yield_with_args(bot, bots[0])
+    end 
+
+    it 'should not hit when the bullet is far away but on a direct path to bot' do
+      bots = [mockbot(50, 50, 'not so deadbot')]
+      shell.speed = 1
+      shell.heading = Math::PI / 4
+      shell.position = shell.position.move(shell.heading, shell.speed)
+      expect { |p| shell.hits(bots, &p) }.not_to yield_with_args(bot, bots[0])
+    end 
+
     it 'should not hit shell outside bot radius' do
-      bots = [mockbot(10 + RTanque::Bot::RADIUS + 0.01, 10, 'deadbot')]
+      bots = [mockbot(10 + RTanque::Bot::RADIUS + 0.01, 10, 'not so deadbot')]
       expect { |p| shell.hits(bots, &p) }.not_to yield_with_args(bot, bots[0])
     end
   end

--- a/spec/rtanque_spec.rb
+++ b/spec/rtanque_spec.rb
@@ -8,7 +8,7 @@ describe RTanque do
       @looser = brain_bot { }
       @winner.position = RTanque::Point.new(0, 0, @arena)
       @winner.turret.heading = RTanque::Heading.new(RTanque::Heading::N)
-      @looser.position = RTanque::Point.new(0, @arena.height, @arena)
+      @looser.position = RTanque::Point.new(0, @arena.height - RTanque::Bot::RADIUS, @arena)
       @match = RTanque::Match.new(@arena, 1000)
       @match.add_bots(@winner, @looser)
     }


### PR DESCRIPTION
The algorithm uses the projection of the vector AB (from bullets
previous location to center of bot) onto AC (from bullets previous
location to new location). If the distance from the projection to the
center of the bot is less than the radius of the bot somewhere along the
way the bullet passed through the bot, resulting in a hit. If the
magnitude of this projection is greater than the magnitude of the
bullets vector then the bullet has not passed through the target
because the bullet has not yet traveled far enough.

Test cases have been added that describe the above.

Here's a graphic representation of the algorithm:

![projection](https://f.cloud.github.com/assets/696255/802070/c3e705a4-edb5-11e2-85d6-bffdd7c3d9f8.png)

This should be thoroughly reviewed.
