### PR TITLE
Changes effecting maximum gun energy

### DIFF
--- a/lib/rtanque/bot.rb
+++ b/lib/rtanque/bot.rb
@@ -49,8 +49,8 @@ module RTanque
     end
 
     def adjust_fire_power
-      @gun_energy ||= MAX_GUN_ENERGY
-      if @gun_energy <= 0
+      @gun_energy ||= 0
+      if @gun_energy < (self.fire_power**RTanque::Shell::RATIO) * GUN_ENERGY_FACTOR
         self.fire_power = 0
       else
         @gun_energy -= (self.fire_power**RTanque::Shell::RATIO) * GUN_ENERGY_FACTOR

--- a/lib/rtanque/configuration.rb
+++ b/lib/rtanque/configuration.rb
@@ -8,6 +8,10 @@ module RTanque
     raise_brain_tick_errors true
     quit_when_finished true
 
+    shell do
+      speed_factor 4.5
+      ratio 1.5 # used by Bot#adjust_fire_power and to calculate damage done by shell to bot
+    end
     bot do
       radius 19
       health_reduction_on_exception 2
@@ -16,8 +20,8 @@ module RTanque
       speed_step 0.05
       turn_step one_degree * 1.5
       fire_power 1..5
-      gun_energy_max 10
       gun_energy_factor 10
+      gun_energy_max (fire_power.max**shell::ratio * gun_energy_factor + 1).to_i
     end
     turret do
       length 28
@@ -26,10 +30,6 @@ module RTanque
     radar do
       turn_step 0.05
       vision -(one_degree * 10.0)..(one_degree * 10.0)
-    end
-    shell do
-      speed_factor 4.5
-      ratio 1.5 # used by Bot#adjust_fire_power and to calculate damage done by shell to bot
     end
     explosion do
       life_span 70 * 1 # should be multiple of the number of frames in the explosion animation


### PR DESCRIPTION
Changed the bot.gun_energy_max in the configuration.rb file to be based
on the energy required to fire one maximum power shell.
Changed the initial gun energy to 0 so that there is a build up time at
the beginning of the game.
Changed the criteria for firing so that the gun energy will never go
below zero.
