### PR TITLE
Upgrade to working versions of gosu and texplay

### DIFF
--- a/rtanque.gemspec
+++ b/rtanque.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
 
 Rules of the game are simple: Last bot standing wins. Gameplay is also pretty simple. Each tank has a base, turret and radar, each of which rotate independently. The base moves the tank, the turret has a gun mounted to it which can fire at other tanks, and the radar detects other tanks in its field of vision.
 
-Have fun competing against friends' tanks or the sample ones included. Maybe you'll start a small league at your local Ruby meetup.} 
+Have fun competing against friends' tanks or the sample ones included. Maybe you'll start a small league at your local Ruby meetup.}
   gem.homepage      = "https://github.com/awilliams/RTanque"
   gem.license       = 'MIT'
 
@@ -22,11 +22,11 @@ Have fun competing against friends' tanks or the sample ones included. Maybe you
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'gosu', '~> 0.7.45'
+  gem.add_dependency 'gosu', '~> 0.8.7'
   gem.add_dependency 'configuration', '~> 1.3.2'
   gem.add_dependency 'octokit', '~> 1.23.0'
   gem.add_dependency 'thor', '~> 0.17.0'
-  gem.add_dependency 'texplay'
+  gem.add_dependency 'texplay', '~> 0.4.4.beta'
 
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rspec', '~> 2.13.0'


### PR DESCRIPTION
Gosu dependencies that need to be installed separately (like SDL) have evolved such that trying to install old versions of Gosu fails on most systems. I had a full meetup group with a variety of operating systems unable to install the gosu gem due to a variety of errors. These updates got everything working again, and while I don't like using the pre release of texplay, that was the only version that would work with the new Gosu. At least it works again though, which is something...