### PR TITLE
Remove chamber from version 0.2

### DIFF
--- a/bin/rtanque
+++ b/bin/rtanque
@@ -4,12 +4,10 @@ require 'thor'
 require 'rtanque'
 require 'rtanque/runner'
 require 'octokit'
-require 'chamber'
 
 class RTanqueCLI < Thor
   include Thor::Actions
-  Chamber.load basepath: '.', namespaces: { environment: 'battle' }
-  BOT_DIR = Chamber.env['bot_dir'] || 'bots'
+  BOT_DIR = RTanque::Configuration.match.bot_dir
 
   source_root(File.expand_path('../../', __FILE__))
 
@@ -35,11 +33,11 @@ LONGDESC
     runner = RTanque::Runner.new(
       width: options[:width],
       height: options[:height],
-      screen: Chamber.env['screen'],
+      screen: RTanque::Configuration.match.screen,
       max_ticks: options[:max_ticks],
       teams: options[:teams]
     )
-    brain_paths = Chamber.env.bots if brain_paths.length == 0
+    brain_paths = RTanque::Configuration.match.bots if brain_paths.length == 0
     brain_paths.each { |brain_path|
       begin
         runner.add_brain_path(brain_path)

--- a/lib/rtanque/configuration.rb
+++ b/lib/rtanque/configuration.rb
@@ -1,13 +1,22 @@
 require 'configuration'
+require 'yaml'
 
 module RTanque
   one_degree = (Math::PI / 180.0)
+
+  file = File.expand_path('settings.yml', '.')
+  settings = File.exist?(file) ? YAML.load_file(file) : {}
 
   # @!visibility private
   Configuration = ::Configuration.for('default') do
     raise_brain_tick_errors true
     quit_when_finished true
 
+    match do
+      screen settings.dig('match', 'screen') || 'silent'
+      bot_dir settings.dig('match', 'bot_dir') || 'bots'
+      bots settings.dig('match', 'bots')
+    end
     bot do
       radius 19
       health_reduction_on_exception 2

--- a/rtanque.gemspec
+++ b/rtanque.gemspec
@@ -25,9 +25,6 @@ Have fun competing against friends' tanks or the sample ones included. Maybe you
   gem.add_dependency 'configuration', '~> 1.3.4'
   gem.add_dependency 'octokit', '~> 10.0.0'
   gem.add_dependency 'thor', '~> 1.4.0'
-  gem.add_dependency 'chamber', '~> 2.14.0'
-  # Required for chamber
-  gem.add_dependency 'base64', '~> 0.3.0'
 
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rspec', '~> 3.7.0'

--- a/templates/settings.yml
+++ b/templates/settings.yml
@@ -1,15 +1,16 @@
-battle:
+match:
   # Define the output method. For example.
-  #   silent : No output and just display the winner
+  #   silent : No output and just display the winner (default)
   #   text   : Display the game state at each step in text
   #   gosu   : Graphical display using the Gosu library
   #            Requires the 'rtanque-gosu' gem
-  screen: silent        # Default
+  # screen: silent
 
-  # Location of bots
-  bot_dir: bots         # Default
+  # Location of bots (default - bots)
+  # bot_dir: bots
 
   # Bots to include in the battle
-  bots:
-    - sample_bots/camper
-    - sample_bots/seek_and_destroy
+  # If this option is omitted then bots must be added on the command line
+  # bots:
+  #   - sample_bots/camper
+  #   - sample_bots/seek_and_destroy


### PR DESCRIPTION
I had added the `chamber` gem to load a settings file. This is overkill as it can just be read in using the built-in `yaml` gem. All the features around security and multiple environments is unnecessary.