### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/lib/rtanque/version.rb
+++ b/lib/rtanque/version.rb
@@ -1,3 +1,3 @@
 module RTanque
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
I should probably have created this PR a couple of week ago.

Preparing for a new version, 0.1.4. The significant changes in this release:

* Update to [gosu](/gosu/gosu) version 1.4.6
* Remove dependency on [texplay](/banister/texplay)

Let me know if you want me to push the gem to Rubygems. Otherwise, I will assume you will.